### PR TITLE
Fix getMousePosition when svg has viewBox

### DIFF
--- a/packages/core/src/drauu.ts
+++ b/packages/core/src/drauu.ts
@@ -4,6 +4,7 @@ import { Brush, Options, DrawingMode, EventsMap } from './types'
 
 export class Drauu {
   el: SVGSVGElement | null = null
+  elPoint: DOMPoint | null = null
   eventEl: Element | null = null
   shiftPressed = false
   altPressed = false
@@ -62,6 +63,8 @@ export class Drauu {
       throw new Error('[drauu] target element not found')
     if (this.el.tagName !== 'svg')
       throw new Error('[drauu] can only mount to a SVG element')
+
+    this.elPoint = this.el.createSVGPoint()
 
     const target: SVGSVGElement = this.resolveSelector(eventEl as any) || this.el!
 

--- a/packages/core/src/drauu.ts
+++ b/packages/core/src/drauu.ts
@@ -4,7 +4,7 @@ import { Brush, Options, DrawingMode, EventsMap } from './types'
 
 export class Drauu {
   el: SVGSVGElement | null = null
-  elPoint: DOMPoint | null = null
+  svgPoint: DOMPoint | null = null
   eventEl: Element | null = null
   shiftPressed = false
   altPressed = false
@@ -64,7 +64,7 @@ export class Drauu {
     if (this.el.tagName !== 'svg')
       throw new Error('[drauu] can only mount to a SVG element')
 
-    this.elPoint = this.el.createSVGPoint()
+    this.svgPoint = this.el.createSVGPoint()
 
     const target: SVGSVGElement = this.resolveSelector(eventEl as any) || this.el!
 

--- a/packages/core/src/models/base.ts
+++ b/packages/core/src/models/base.ts
@@ -37,12 +37,15 @@ export abstract class BaseModel<T extends SVGElement> {
   }
 
   getMousePosition(event: PointerEvent): Point {
-    const rect = this.drauu.el!.getBoundingClientRect()
+    const el = this.drauu.el!
+    const pt = this.drauu.elPoint!
     const scale = this.drauu.options.coordinateScale ?? 1
-
+    pt.x = event.clientX
+    pt.y = event.clientY
+    const loc = pt.matrixTransform(el.getScreenCTM()?.inverse())
     return {
-      x: (event.pageX - rect.left) * scale,
-      y: (event.pageY - rect.top) * scale,
+      x: loc.x * scale,
+      y: loc.y * scale,
       pressure: event.pressure,
     }
   }

--- a/packages/core/src/models/base.ts
+++ b/packages/core/src/models/base.ts
@@ -38,11 +38,11 @@ export abstract class BaseModel<T extends SVGElement> {
 
   getMousePosition(event: PointerEvent): Point {
     const el = this.drauu.el!
-    const pt = this.drauu.elPoint!
+    const point = this.drauu.svgPoint!
     const scale = this.drauu.options.coordinateScale ?? 1
-    pt.x = event.clientX
-    pt.y = event.clientY
-    const loc = pt.matrixTransform(el.getScreenCTM()?.inverse())
+    point.x = event.clientX
+    point.y = event.clientY
+    const loc = point.matrixTransform(el.getScreenCTM()?.inverse())
     return {
       x: loc.x * scale,
       y: loc.y * scale,


### PR DESCRIPTION
Hi!
Firstly thanks for this awesome library :muscle:
I want to use it in my pet project, where I work with SVG a lot, and I found a small bug.
When we use `viewBox` on SVG, then `getMousePosition` works incorrectly. The proper way that I found is kinda this:
```js
// Find your root SVG element
var svg = document.querySelector('svg');

// Create an SVGPoint for future math
var pt = svg.createSVGPoint();

// Get point in global SVG space
function cursorPoint(evt){
  pt.x = evt.clientX; pt.y = evt.clientY;
  return pt.matrixTransform(svg.getScreenCTM().inverse());
}

svg.addEventListener('mousemove',function(evt){
  var loc = cursorPoint(evt);
  // Use loc.x and loc.y here
},false);
```
the original answer is here:
https://stackoverflow.com/a/10298843/4729613

the reproduction link is here:
https://codesandbox.io/s/muddy-feather-7k78f?file=/src/index.js