### PR TITLE
fix: shouldn't clear undoStack when is not drawing

### DIFF
--- a/packages/core/src/drauu.ts
+++ b/packages/core/src/drauu.ts
@@ -8,6 +8,7 @@ export class Drauu {
   eventEl: Element | null = null
   shiftPressed = false
   altPressed = false
+  drawing = false
 
   private _emitter = createNanoEvents<EventsMap>()
   private _models = createModels(this)
@@ -131,7 +132,7 @@ export class Drauu {
   }
 
   private eventMove(event: PointerEvent) {
-    if (!this.acceptsInput(event))
+    if (!this.acceptsInput(event) || !this.drawing)
       return
 
     if (this.model._eventMove(event)) {
@@ -148,6 +149,7 @@ export class Drauu {
     event.preventDefault()
     if (this._currentNode)
       this.cancel()
+    this.drawing = true
     this._emitter.emit('start')
     this._currentNode = this.model._eventDown(event)
     if (this._currentNode)
@@ -156,7 +158,7 @@ export class Drauu {
   }
 
   private eventEnd(event: PointerEvent) {
-    if (!this.acceptsInput(event))
+    if (!this.acceptsInput(event) || !this.drawing)
       return
     const result = this.model._eventUp(event)
     if (!result) {
@@ -167,6 +169,7 @@ export class Drauu {
         this._currentNode = result
       this.commit()
     }
+    this.drawing = false
     this._emitter.emit('end')
     this._emitter.emit('changed')
   }


### PR DESCRIPTION
Fixed the redo function when using button.

Click event in `window` will trigger `pointerup` event, which will trigger `commit()` to clear the undoStack.