### PR TITLE
feat: add eraser support

### DIFF
--- a/packages/core/src/drauu.ts
+++ b/packages/core/src/drauu.ts
@@ -36,7 +36,11 @@ export class Drauu {
   }
 
   set mode(v: DrawingMode) {
+    const unselected = this._models[this.mode]
+    unselected.onUnselected()
+
     this.options.brush!.mode = v
+    this.model.onSelected(this.el)
   }
 
   get brush() {
@@ -154,7 +158,7 @@ export class Drauu {
     this.drawing = true
     this._emitter.emit('start')
     this._currentNode = this.model._eventDown(event)
-    if (this._currentNode)
+    if (this._currentNode && this.mode !== 'eraseLine')
       this.el!.appendChild(this._currentNode)
     this._emitter.emit('changed')
   }

--- a/packages/core/src/models/base.ts
+++ b/packages/core/src/models/base.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Brush } from '../types'
+import { Point, Brush } from '../types'
 import { Drauu } from '../drauu'
-import { Point } from '../types'
 import { D } from '../utils'
 
 export abstract class BaseModel<T extends SVGElement> {
@@ -10,7 +9,13 @@ export abstract class BaseModel<T extends SVGElement> {
   start: Point = undefined!
   el: T | null = null
 
-  constructor(private drauu: Drauu) {}
+  constructor(protected drauu: Drauu) {}
+
+  onSelected(el: SVGSVGElement | null): void {
+  }
+
+  onUnselected(): void {
+  }
 
   onStart(point: Point): SVGElement | undefined {
     return undefined
@@ -34,6 +39,10 @@ export abstract class BaseModel<T extends SVGElement> {
 
   get altPressed() {
     return this.drauu.altPressed
+  }
+
+  get svgElement() {
+    return this.drauu.el
   }
 
   getMousePosition(event: PointerEvent): Point {

--- a/packages/core/src/models/eraser.ts
+++ b/packages/core/src/models/eraser.ts
@@ -1,0 +1,115 @@
+import { Point } from '../types'
+import { BaseModel } from './base'
+
+export class EraserModel extends BaseModel<SVGRectElement> {
+  svgPointPrevious?: DOMPoint
+  svgPointCurrent?: DOMPoint
+
+  pathSubFactor = 20
+  pathFragments: { x1: number; x2: number; y1: number; y2: number; segment: number; element: any }[] = []
+
+  onSelected(el: SVGSVGElement | null): void {
+    const calculatePathFragments = (children: any, element?: any): void => {
+      if (children && children.length) {
+        for (let i = 0; i < children.length; i++) {
+          const ele = children[i] as any
+          if (ele.getTotalLength) {
+            const pathLength = ele.getTotalLength()
+
+            for (let j = 0; j < this.pathSubFactor; j++) {
+              const pos1 = ele.getPointAtLength(pathLength * j / this.pathSubFactor)
+              const pos2 = ele.getPointAtLength(pathLength * (j + 1) / this.pathSubFactor)
+              this.pathFragments.push({
+                x1: pos1.x,
+                x2: pos2.x,
+                y1: pos1.y,
+                y2: pos2.y,
+                segment: j,
+                element: element || ele,
+              })
+            }
+          }
+          else {
+            if (ele.children) calculatePathFragments(ele.children, ele)
+          }
+        }
+      }
+    }
+
+    if (el) calculatePathFragments(el.children)
+  }
+
+  onUnselected(): void {
+    this.pathFragments = []
+  }
+
+  override onStart(point: Point) {
+    this.svgPointPrevious = this.svgElement!.createSVGPoint()
+    this.svgPointPrevious.x = point.x
+    this.svgPointPrevious.y = point.y
+    return undefined
+  }
+
+  override onMove(point: Point) {
+    this.svgPointCurrent = this.svgElement!.createSVGPoint()
+    this.svgPointCurrent.x = point.x
+    this.svgPointCurrent.y = point.y
+    const erased = this.checkAndEraseElement()
+    this.svgPointPrevious = this.svgPointCurrent
+    return erased
+  }
+
+  override onEnd() {
+    this.svgPointPrevious = undefined
+    this.svgPointCurrent = undefined
+    return true
+  }
+
+  private checkAndEraseElement() {
+    const erased: number[] = []
+    if (this.pathFragments.length) {
+      for (let i = 0; i < this.pathFragments.length; i++) {
+        const segment = this.pathFragments[i]
+        const line = {
+          x1: this.svgPointPrevious!.x,
+          x2: this.svgPointCurrent!.x,
+          y1: this.svgPointPrevious!.y,
+          y2: this.svgPointCurrent!.y,
+        }
+        if (this.lineLineIntersect(segment, line)) {
+          segment.element.remove()
+          erased.push(i)
+        }
+      }
+    }
+
+    if (erased.length) this.pathFragments = this.pathFragments.filter((v, i) => !erased.includes(i))
+    return erased.length > 0
+  }
+
+  private lineLineIntersect(line1: any, line2: any): boolean {
+    const x1 = line1.x1
+    const x2 = line1.x2
+    const x3 = line2.x1
+    const x4 = line2.x2
+    const y1 = line1.y1
+    const y2 = line1.y2
+    const y3 = line2.y1
+    const y4 = line2.y2
+    const pt_denom = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4)
+    const pt_x_num = (x1 * y2 - y1 * x2) * (x3 - x4) - (x1 - x2) * (x3 * y4 - y3 * x4)
+    const pt_y_num = (x1 * y2 - y1 * x2) * (y3 - y4) - (y1 - y2) * (x3 * y4 - y3 * x4)
+    const btwn = (a: number, b1: number, b2: number): boolean => {
+      if ((a >= b1) && (a <= b2)) return true
+      return (a >= b2) && (a <= b1)
+    }
+    if (pt_denom === 0) { return false }
+    else {
+      const pt = {
+        x: pt_x_num / pt_denom,
+        y: pt_y_num / pt_denom,
+      }
+      return btwn(pt.x, x1, x2) && btwn(pt.y, y1, y2) && btwn(pt.x, x3, x4) && btwn(pt.y, y3, y4)
+    }
+  }
+}

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -7,6 +7,7 @@ import { EllipseModel } from './ellipse'
 import { LineModel } from './line'
 import { RectModel } from './rect'
 import { DrawModel } from './draw'
+import { EraserModel } from './eraser'
 
 export function createModels(drauu: Drauu): Record<DrawingMode, BaseModel<SVGElement>> {
   return {
@@ -15,5 +16,6 @@ export function createModels(drauu: Drauu): Record<DrawingMode, BaseModel<SVGEle
     line: new LineModel(drauu),
     rectangle: new RectModel(drauu),
     ellipse: new EllipseModel(drauu),
+    eraseLine: new EraserModel(drauu),
   }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,6 @@
 import type { StrokeOptions } from 'perfect-freehand'
 
-export type DrawingMode = 'draw' | 'stylus' | 'line' | 'rectangle' | 'ellipse'
+export type DrawingMode = 'draw' | 'stylus' | 'line' | 'rectangle' | 'ellipse' | 'eraseLine'
 
 export interface Brush {
   /**

--- a/playground/index.html
+++ b/playground/index.html
@@ -25,6 +25,7 @@
       <button id="clear" aria-label="Clear" title="Clear">🗑</button>
       <div class="mx-4 opacity-25">/</div>
       <button class="active" id="m-stylus" aria-label="Stylus" title="Stylus">✍️</button>
+      <button id="m-eraser" aria-label="Eraser" title="Eraser">⚪️</button>
       <button id="m-draw" aria-label="Draw" title="Draw">✏️</button>
       <button id="m-line" aria-label="Line" title="Line">⁄</button>
       <button id="m-arrow" aria-label="Arrow" title="Arrow">↗</button>

--- a/playground/main.ts
+++ b/playground/main.ts
@@ -1,5 +1,5 @@
 import 'virtual:windi.css'
-import { createDrauu, Brush } from 'drauu'
+import { createDrauu, Brush, DrawingMode } from 'drauu'
 import './style.css'
 
 const drauu = createDrauu({
@@ -68,6 +68,7 @@ sizeEl.addEventListener('input', () => drauu.brush.size = +sizeEl.value)
 
 const modes: { el: HTMLElement; brush: Partial<Brush> }[] = [
   { el: document.getElementById('m-stylus')!, brush: { mode: 'stylus', arrowEnd: false } },
+  { el: document.getElementById('m-eraser')!, brush: { mode: 'eraseLine', arrowEnd: false } },
   { el: document.getElementById('m-draw')!, brush: { mode: 'draw', arrowEnd: false } },
   { el: document.getElementById('m-line')!, brush: { mode: 'line', arrowEnd: false } },
   { el: document.getElementById('m-arrow')!, brush: { mode: 'line', arrowEnd: true } },
@@ -78,7 +79,8 @@ modes.forEach(({ el, brush }) => {
   el.addEventListener('click', () => {
     modes.forEach(({ el }) => el.classList.remove('active'))
     el.classList.add('active')
-    Object.assign(drauu.brush, brush)
+    drauu.brush.arrowEnd = brush.arrowEnd
+    drauu.mode = brush.mode as DrawingMode
   })
 })
 


### PR DESCRIPTION
The eraser function using a simple approximate solution to path-line intersection by subdividing the path (via the built-in svg path function [.getPointAtLength](https://developer.mozilla.org/en-US/docs/Web/API/SVGPathElement)) into an arbitrary number of straight line segments and testing for line-line intersections at each one.

More tech details about line-line intersections: [Line–line intersection algorithms](https://en.wikipedia.org/wiki/Line%E2%80%93line_intersection#Given_two_points_on_each_line)