### PR TITLE
fix: incorrect sizing between brush types

### DIFF
--- a/packages/core/src/models/stylus.ts
+++ b/packages/core/src/models/stylus.ts
@@ -38,7 +38,7 @@ export class StylusModel extends BaseModel<SVGPathElement> {
 
   getSvgData(points: Point[]) {
     const stroke = pf.getStroke(points, {
-      size: this.brush.size * 2,
+      size: this.brush.size,
       thinning: 0.9,
       simulatePressure: false,
       start: {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

For the stylus tool we double our brush size when generating the path data, resulting in a line twice the thickness of other tools

https://github.com/antfu/drauu/blob/a93fdf094eda08ac22a6f6c380385f3f5c9a2e9a/packages/core/src/models/stylus.ts#L40-L51
### Linked Issues

Fixes #30 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
