### PR TITLE
fix: multitouch events draw incorrectly

### DIFF
--- a/packages/core/src/drauu.ts
+++ b/packages/core/src/drauu.ts
@@ -11,6 +11,7 @@ export class Drauu {
   drawing = false
 
   private _emitter = createNanoEvents<EventsMap>()
+  private _originalPointerId: number | null = null
   private _models = createModels(this)
   private _currentNode: SVGElement | undefined
   private _undoStack: Node[] = []
@@ -156,6 +157,7 @@ export class Drauu {
     if (this._currentNode)
       this.cancel()
     this.drawing = true
+    this._originalPointerId = event.pointerId
     this._emitter.emit('start')
     this._currentNode = this.model._eventDown(event)
     if (this._currentNode && this.mode !== 'eraseLine')
@@ -178,11 +180,12 @@ export class Drauu {
     this.drawing = false
     this._emitter.emit('end')
     this._emitter.emit('changed')
+    this._originalPointerId = null
   }
 
   private acceptsInput(event: PointerEvent) {
-    return !this.options.acceptsInputTypes
-    || this.options.acceptsInputTypes.includes(event.pointerType as any)
+    return (!this.options.acceptsInputTypes || this.options.acceptsInputTypes.includes(event.pointerType as any))
+          && !(this._originalPointerId && this._originalPointerId !== event.pointerId)
   }
 
   private eventKeyboard(event: KeyboardEvent) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Fixes #32 

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

In #32 we detail the current bug regarding drawing with multiple touch pointers.

In this PR we aim to handle this by keeping track of the original touch pointer's ID in the `eventStart` method, and ignoring subsequent events if the original pointer ID exists and is different from the current event's pointer ID

### Linked Issues

#32 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
