### PR TITLE
fix(playground): Make ellipse unicode icon center

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -29,7 +29,7 @@
       <button id="m-line" aria-label="Line" title="Line">⁄</button>
       <button id="m-arrow" aria-label="Arrow" title="Arrow">↗</button>
       <button id="m-rect" aria-label="Rect" title="Rect">⃞</button>
-      <button id="m-ellipse" aria-label="Ellipse" title="Ellipse">⃝</button>
+      <button id="m-ellipse" aria-label="Ellipse" title="Ellipse">𐤏</button>
       <button id="m-eraser" aria-label="Eraser" title="Eraser">🧹</button>
       <div class="mx-4 opacity-25">/</div>
       <button data-color="#000000" class="active">​⚫️​</button>


### PR DESCRIPTION

### Description

When using the demo at https://drauu.netlify.app/, I noticed that the ellipse icon was not horizontally centered due to Unicode. So, I replaced the Unicode for the ellipse to ensure that the icon is displayed in the center. I used [𐤏](https://commons.wikimedia.org/wiki/Category:Unicode_10900-1091F_Phoenician?uselang=en) for this purpose.

在使用 https://drauu.netlify.app/ Demo 的时候，看到椭圆的 Icon 因为 unicode 的原因，水平方向并不居中。于是我更换了一下椭圆的 unicode ，以至于让 Icon 居中显示。使用的是[ 𐤏 ](https://commons.wikimedia.org/wiki/Category:Unicode_10900-1091F_Phoenician?uselang=zh-cn)

![image](https://github.com/antfu/drauu/assets/42307398/db49ec8f-6498-45ff-9812-5673d2dde0e8)
