### PR TITLE
feat: add custom window support

### DIFF
--- a/packages/core/src/drauu.ts
+++ b/packages/core/src/drauu.ts
@@ -21,7 +21,7 @@ export class Drauu {
     if (!this.options.brush)
       this.options.brush = { color: 'black', size: 3, mode: 'stylus' }
     if (options.el)
-      this.mount(options.el, options.eventTarget)
+      this.mount(options.el, options.eventTarget, options.listenWindow)
   }
 
   get model() {
@@ -59,7 +59,7 @@ export class Drauu {
       return selector || null
   }
 
-  mount(el: string | SVGSVGElement, eventEl?: string | Element) {
+  mount(el: string | SVGSVGElement, eventEl?: string | Element, listenWindow: Window = window) {
     if (this.el)
       throw new Error('[drauu] already mounted, unmount previous target first')
 
@@ -82,19 +82,19 @@ export class Drauu {
     const keyboard = this.eventKeyboard.bind(this)
 
     target.addEventListener('pointerdown', start, { passive: false })
-    window.addEventListener('pointermove', move, { passive: false })
-    window.addEventListener('pointerup', end, { passive: false })
-    window.addEventListener('pointercancel', end, { passive: false })
-    window.addEventListener('keydown', keyboard, false)
-    window.addEventListener('keyup', keyboard, false)
+    listenWindow.addEventListener('pointermove', move, { passive: false })
+    listenWindow.addEventListener('pointerup', end, { passive: false })
+    listenWindow.addEventListener('pointercancel', end, { passive: false })
+    listenWindow.addEventListener('keydown', keyboard, false)
+    listenWindow.addEventListener('keyup', keyboard, false)
 
     this._disposables.push(() => {
       target.removeEventListener('pointerdown', start)
-      window.removeEventListener('pointermove', move)
-      window.removeEventListener('pointerup', end)
-      window.removeEventListener('pointercancel', end)
-      window.removeEventListener('keydown', keyboard, false)
-      window.removeEventListener('keyup', keyboard, false)
+      listenWindow.removeEventListener('pointermove', move)
+      listenWindow.removeEventListener('pointerup', end)
+      listenWindow.removeEventListener('pointercancel', end)
+      listenWindow.removeEventListener('keydown', keyboard, false)
+      listenWindow.removeEventListener('keyup', keyboard, false)
     })
 
     this._emitter.emit('mounted')

--- a/packages/core/src/drauu.ts
+++ b/packages/core/src/drauu.ts
@@ -21,7 +21,7 @@ export class Drauu {
     if (!this.options.brush)
       this.options.brush = { color: 'black', size: 3, mode: 'stylus' }
     if (options.el)
-      this.mount(options.el, options.eventTarget, options.listenWindow)
+      this.mount(options.el, options.eventTarget, options.window)
   }
 
   get model() {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -78,6 +78,14 @@ export interface Options {
   eventTarget?: string | Element
 
   /**
+   * Listen to a different window for mouse events.
+   * Useful when you have an iframe or a popup.
+   *
+   * @default window
+   */
+  listenWindow?: Window
+
+  /**
    * When you apply a scale transform to the svg container,
    * set this property to let drauu aware of the currect coordinates.
    * @default 1

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -83,7 +83,7 @@ export interface Options {
    *
    * @default window
    */
-  listenWindow?: Window
+  window?: Window
 
   /**
    * When you apply a scale transform to the svg container,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Adds support to listen mouse events from a window that isn't the default.

### Linked Issues


### Additional context

I was trying to setup drauu on a popup, which has a different window. The problem was that `window` still references the main window instead of the popup, so the coordinates emitted by the mouse events were way off. This PR fixes that.
