### PR TITLE
feat: support `cssZoom` option for older Chrome versions

### DIFF
--- a/packages/core/src/models/base.ts
+++ b/packages/core/src/models/base.ts
@@ -46,21 +46,22 @@ export abstract class BaseModel<T extends SVGElement> {
 
   getMousePosition(event: PointerEvent): Point {
     const el = this.drauu.el!
+    const cssZoom = this.drauu.options.cssZoom ?? 1
     const scale = this.drauu.options.coordinateScale ?? 1
     const offset = this.drauu.options.offset ?? { x: 0, y: 0 }
 
     if (this.drauu.options.coordinateTransform === false) {
       const rect = this.drauu.el!.getBoundingClientRect()
       return {
-        x: (event.pageX - rect.left + offset.x) * scale,
-        y: (event.pageY - rect.top + offset.y) * scale,
+        x: (event.pageX / cssZoom - rect.left + offset.x) * scale,
+        y: (event.pageY / cssZoom - rect.top + offset.y) * scale,
         pressure: event.pressure,
       }
     }
     else {
       const point = this.drauu.svgPoint!
-      point.x = event.clientX + offset.x
-      point.y = event.clientY + offset.y
+      point.x = event.clientX / cssZoom + offset.x
+      point.y = event.clientY / cssZoom + offset.y
       const loc = point.matrixTransform(el.getScreenCTM()?.inverse())
       return {
         x: loc.x * scale,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -101,6 +101,13 @@ export interface Options {
   coordinateTransform?: boolean
 
   /**
+   * To calculate the correct touch and mouse event positions for
+   * elements using the zoom property on older Chrome versions(before 96)
+   * @default 1
+   */
+  cssZoom?: number
+
+  /**
    * Sets the offset of the transformation when calculating coordinates.
    *
    * @default { x: 0, y: 0 }


### PR DESCRIPTION
### Description

fix a bug where touch and mouse events return incorrect coordinates when the zoom property is applied to the parent element. This issue affects Chrome versions before 96, where event coordinates (clientX, clientY) are not scaled properly according to the zoom factor.

For newer versions of Chrome (96+), no adjustment is needed since the browser handles zoom scaling correctly. This fix ensures consistent behavior by manually adjusting event coordinates based on the zoom factor in older versions.

### Steps to Reproduce
1. Use any Chrome version prior to 96.
2. Apply a zoom property to the drauu svg parent node
3. Observing the result of the drawing, we can see that there is a clear deviation from the actual mouse/touch position.
4. Set the correct cssZoom value in drauu option and draw again, and you can see that the situation has returned to normal.

###  Why This is Needed
• Touch and mouse event coordinates are incorrect on older versions of Chrome when zoom is applied, causing misaligned interactions.
• This fix makes sure users have a consistent experience regardless of their browser version.

###  Browser Version Coverage
• Chrome 81 && 88: Verified the issue exists and is fixed with this patch.
• Chrome 96+: Already handles zoom properly; this fix remains compatible.

### Additional Notes
This patch doesn’t interfere with newer Chrome versions and gracefully handles legacy versions. It helps users who still use older browsers without impacting performance or modern browser handling.

Let’s make zoomed elements behave nicely! 👋
